### PR TITLE
Reduce memory allocation by using .collect()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,15 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dev-dependencies]
+criterion = "0.4.0"
+
 [dependencies]
 once_cell = "1.9.0"
+
+[profile.bench]
+debug = true
+
+[[bench]]
+name = "normalize"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sugar_path"
 description = "Sugar functions for manipulating paths"
 repository = "https://github.com/iheyunfei/sugar_path"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 license = "MIT"
 

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -75,7 +75,7 @@ fn normalize() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("normalize", |b| b.iter(|| normalize()));
+    c.bench_function("normalize", |b| b.iter(normalize));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use sugar_path::SugarPath;
+
+fn normalize() {
+    assert_eq!(
+        Path::new("/foo/../../../bar").normalize(),
+        Path::new("/bar")
+    );
+    assert_eq!(Path::new("a//b//../b").normalize(), Path::new("a/b"));
+    assert_eq!(
+        Path::new("/foo/../../../bar").normalize(),
+        Path::new("/bar")
+    );
+    assert_eq!(Path::new("a//b//./c").normalize(), Path::new("a/b/c"));
+    assert_eq!(Path::new("a//b//.").normalize(), Path::new("a/b"));
+    assert_eq!(
+        Path::new("/a/b/c/../../../x/y/z").normalize(),
+        Path::new("/x/y/z")
+    );
+    assert_eq!(
+        Path::new("///..//./foo/.//bar").normalize(),
+        Path::new("/foo/bar")
+    );
+    assert_eq!(Path::new("bar/foo../../").normalize(), Path::new("bar/"));
+    assert_eq!(Path::new("bar/foo../..").normalize(), Path::new("bar"));
+    assert_eq!(
+        Path::new("bar/foo../../baz").normalize(),
+        Path::new("bar/baz")
+    );
+    assert_eq!(Path::new("bar/foo../").normalize(), Path::new("bar/foo../"));
+    assert_eq!(Path::new("bar/foo..").normalize(), Path::new("bar/foo.."));
+    assert_eq!(
+        Path::new("../foo../../../bar").normalize(),
+        Path::new("../../bar")
+    );
+    assert_eq!(
+        Path::new("../foo../../../bar").normalize(),
+        Path::new("../../bar")
+    );
+    assert_eq!(
+        Path::new("../.../.././.../../../bar").normalize(),
+        Path::new("../../bar")
+    );
+    assert_eq!(
+        Path::new("../.../.././.../../../bar").normalize(),
+        Path::new("../../bar")
+    );
+    assert_eq!(
+        Path::new("../../../foo/../../../bar").normalize(),
+        Path::new("../../../../../bar")
+    );
+    assert_eq!(
+        Path::new("../../../foo/../../../bar/../../").normalize(),
+        Path::new("../../../../../../")
+    );
+    assert_eq!(
+        Path::new("../foobar/barfoo/foo/../../../bar/../../").normalize(),
+        Path::new("../../")
+    );
+    assert_eq!(
+        Path::new("../.../../foobar/../../../bar/../../baz").normalize(),
+        Path::new("../../../../baz")
+    );
+    assert_eq!(
+        Path::new("foo/bar\\baz").normalize(),
+        Path::new("foo/bar\\baz")
+    );
+    assert_eq!(Path::new("/a/b/c/../../../").normalize(), Path::new("/"));
+    assert_eq!(Path::new("a/b/c/../../../").normalize(), Path::new("."));
+    assert_eq!(Path::new("a/b/c/../../..").normalize(), Path::new("."));
+
+    assert_eq!(Path::new("").normalize(), Path::new("."));
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("normalize", |b| b.iter(|| normalize()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/sugar_path.rs
+++ b/src/sugar_path.rs
@@ -117,11 +117,7 @@ fn normalize_to_component_vec(path: &Path) -> Vec<Component> {
 fn component_vec_to_path_buf(components: Vec<Component>) -> PathBuf {
     components
         .into_iter()
-        .map(|c| c.as_os_str())
-        .fold(PathBuf::new(), |mut acc, cur| {
-            acc.push(cur);
-            acc
-        })
+        .collect()
 }
 
 impl SugarPath for Path {

--- a/src/sugar_path.rs
+++ b/src/sugar_path.rs
@@ -7,8 +7,8 @@ use once_cell::sync::Lazy;
 
 pub(crate) static CWD: Lazy<PathBuf> = Lazy::new(|| {
     // TODO: better way to get the current working directory?
-    let cwd = std::env::current_dir().unwrap();
-    cwd
+    
+    std::env::current_dir().unwrap()
 });
 
 pub trait SugarPath {
@@ -75,7 +75,7 @@ fn normalize_to_component_vec(path: &Path) -> Vec<Component> {
     let mut components = path.components().peekable();
     let mut ret = Vec::with_capacity(components.size_hint().0);
     if let Some(c @ Component::Prefix(..)) = components.peek() {
-        ret.push(c.clone());
+        ret.push(*c);
         components.next();
     };
 
@@ -124,7 +124,7 @@ impl SugarPath for Path {
     fn normalize(&self) -> PathBuf {
         if cfg!(target_family = "windows") {
             // TODO: we may need to do it more delegated
-            let path = PathBuf::from(self.to_string_lossy().to_string().replace("/", "\\"));
+            let path = PathBuf::from(self.to_string_lossy().to_string().replace('/', "\\"));
             let mut components = normalize_to_component_vec(&path);
             if components.is_empty()
                 || (components.len() == 1 && matches!(components[0], Component::Prefix(_)))
@@ -134,7 +134,7 @@ impl SugarPath for Path {
             component_vec_to_path_buf(components)
         } else {
             let mut components = normalize_to_component_vec(self);
-            if components.len() == 0 {
+            if components.is_empty() {
                 components.push(Component::CurDir)
             }
             component_vec_to_path_buf(components)
@@ -142,7 +142,7 @@ impl SugarPath for Path {
     }
     fn resolve(&self) -> PathBuf {
         if cfg!(target_family = "windows") {
-            let path = PathBuf::from(self.to_string_lossy().to_string().replace("/", "\\"));
+            let path = PathBuf::from(self.to_string_lossy().to_string().replace('/', "\\"));
             // Consider c:
             if path.is_absolute() {
                 path.normalize()
@@ -165,14 +165,12 @@ impl SugarPath for Path {
                     cwd.normalize()
                 }
             }
+        } else if self.is_absolute() {
+            self.normalize()
         } else {
-            if self.is_absolute() {
-                self.normalize()
-            } else {
-                let mut cwd = CWD.clone();
-                cwd.push(self);
-                cwd.normalize()
-            }
+            let mut cwd = CWD.clone();
+            cwd.push(self);
+            cwd.normalize()
         }
     }
 


### PR DESCRIPTION
It turns out we could `collect` a `PathBuf` from `Iterator<Item=Component>`. This should give rust compiler a hint to do optimizations like pre-allocate memory. https://github.com/rust-lang/rust/issues/41866.



Fix #7.